### PR TITLE
Typos in yaml headers

### DIFF
--- a/Source/MooDialog.Fx.js
+++ b/Source/MooDialog.Fx.js
@@ -4,7 +4,7 @@ name: MooDialog.Fx
 description: Overwrite the default events so the Dialogs are using Fx on open and close
 authors: Arian Stolwijk
 license: MIT-style license
-requires: [Cores/Fx.Tween, Overlay]
+requires: [Core/Fx.Tween, Overlay]
 provides: MooDialog.Fx
 ...
 */

--- a/Source/MooDialog.js
+++ b/Source/MooDialog.js
@@ -4,7 +4,7 @@ name: MooDialog
 description: The base class of MooDialog
 authors: Arian Stolwijk
 license:  MIT-style license
-requires: [Core/Class, Core/Element, Core/Element.Styles, Core/Element.Event]
+requires: [Core/Class, Core/Element, Core/Element.Style, Core/Element.Event]
 provides: [MooDialog, Element.MooDialog]
 ...
 */


### PR DESCRIPTION
Hi Arian.

A quick fix in yaml headers so your great library can be used with the mootools packager.
